### PR TITLE
Remove JobAppmanager links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Things to know for editing
+- main.html is the primary template; everything else is in templates/
+- index.html is the generated page that gets hosted by GitHub Pages.
+- To modify most content, modify main.py.
+- Note that some content is hard-coded in templates and those may need to be adjusted.
+- GitHub only deploys index.html. To build index.html, run main.py to regenerate it. This could be moved to a workflow at some point.

--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
                     <div class="dropdown-menu" aria-labelledby="projectMenuButton">
                         <a class="dropdown-item" href="http://lucascorcodilos.com/blog/">Blog</a>
                         <a class="dropdown-item" href="http://lucascorcodilos.com/RecipeRepo/">RecipeRepo</a>
-                        <a class="dropdown-item" href="https://jobs.lucascorcodilos.com">Job App Manager</a>
                     </div>
                 </div>
             </li>
@@ -447,12 +446,6 @@
         
     <div class="mt-2 ms-4 me-4 mb-0">
         
-            <ul class="project-links">
-                
-                    <li><a href="https://jobs.lucascorcodilos.com">Website</a></li>
-                
-            </ul>
-        
         
         
             
@@ -461,7 +454,7 @@
                             Stores dates/times, notes, resume version, and other information with sort and filter
                             functionality to make it easier to track 100s of job applications.</p>
 
-    <p class="mb-3">Developed in Django and deployed with AWS Elastic Beanstalk.</p>
+    <p class="mb-3">Developed in Django and deployed with AWS Elastic Beanstalk (EOL: April 2023).</p>
 
             
         

--- a/main.py
+++ b/main.py
@@ -177,7 +177,7 @@ if __name__ == '__main__':
                 Project(
                     ID='JAM', header='Job Application Manager', subheader='Creator, Lead Developer',
                     links=[
-                        ('Website', 'https://jobs.lucascorcodilos.com'),
+                        # ('Website', 'https://jobs.lucascorcodilos.com'),
                         # ('Source code', 'https://github.com/lcorcodilos/TIMBER')
                     ],
                     items=[
@@ -185,7 +185,7 @@ if __name__ == '__main__':
                             '''An online tool to track and manage job applications and interviews.
                             Stores dates/times, notes, resume version, and other information with sort and filter
                             functionality to make it easier to track 100s of job applications.''',
-                            '''Developed in Django and deployed with AWS Elastic Beanstalk.'''
+                            '''Developed in Django and deployed with AWS Elastic Beanstalk (EOL: April 2023).'''
                         ])
                     ]
                 ),

--- a/templates/header.html
+++ b/templates/header.html
@@ -11,7 +11,6 @@
                     <div class="dropdown-menu" aria-labelledby="projectMenuButton">
                         <a class="dropdown-item" href="http://lucascorcodilos.com/blog/">Blog</a>
                         <a class="dropdown-item" href="http://lucascorcodilos.com/RecipeRepo/">RecipeRepo</a>
-                        <a class="dropdown-item" href="https://jobs.lucascorcodilos.com">Job App Manager</a>
                     </div>
                 </div>
             </li>


### PR DESCRIPTION
JobAppManager was shut down April 2023 because of AWS costs after my free tier expired.